### PR TITLE
bump Jimver/cuda-toolkit action version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   
       - name: Install NVIDIA CUDA Toolkit
         if: ${{ inputs.install-cuda == 'true' }}
-        uses: Jimver/cuda-toolkit@acce010762576d6d7eafccf022b5e1e808f210b7 # v0.2.11
+        uses: Jimver/cuda-toolkit@dc0ca7bb29c5a92f7a963d3d5c93f8d59765136a # v0.2.14
 
       - name: Setup Cog
         shell: bash


### PR DESCRIPTION
This bumps the pinned version of https://github.com/Jimver/cuda-toolkit from 2.11 to [2.14](https://github.com/Jimver/cuda-toolkit/releases/tag/v0.2.14)

Possible fix for https://github.com/replicate/setup-cog/issues/26