### PR TITLE
fix: 🐛 build fail Failed to Load Docker Image Metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ runs:
   steps:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+        with:
+          use: 'false'
   
       - name: Install NVIDIA CUDA Toolkit
         if: ${{ inputs.install-cuda == 'true' }}


### PR DESCRIPTION
Please see https://github.com/replicate/cog/pull/1656