### PR TITLE
v2: Don't install CUDA by default (and upgrade to latest Cog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This following inputs can be specified using the `with` keyword:
 
 The version of Cog to install in the form `vX.Y.Z`. See [Cog releases](https://github.com/replicate/cog/releases) for a list of available versions.
 
-Defaults to `v0.8.6`.
+Defaults to `v0.9.7`.
 
 ```yml
 - name: Setup Cog
   uses: replicate/setup-cog@v2
   with:
-    cog-version: "v0.9.5"
+    cog-version: "v0.9.8-alpha"
 ```
 
 #### `token`

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install NVIDIA CUDA Toolkit. Defaults to `true`. This flag can be set to `false`
 - name: Setup Cog
   uses: replicate/setup-cog@v1
   with:
-    install-cuda: false
+    install-cuda: true
 ```
 
 ## Example: Manual Deployment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add a step to your workflow that uses this action:
 
 ```yml
 - name: Setup Cog
-  uses: replicate/setup-cog@v1
+  uses: replicate/setup-cog@v2
   with:
     token: ${{ secrets.REPLICATE_API_TOKEN }}
 
@@ -37,7 +37,7 @@ Defaults to `v0.8.6`.
 
 ```yml
 - name: Setup Cog
-  uses: replicate/setup-cog@v1
+  uses: replicate/setup-cog@v2
   with:
     cog-version: "v0.9.5"
 ```
@@ -48,7 +48,7 @@ Your Replicate API token. If set, the Action will automatically authenticate to 
 
 ```yml
 - name: Setup Cog
-  uses: replicate/setup-cog@v1
+  uses: replicate/setup-cog@v2
   with:
     token: ${{ secrets.REPLICATE_API_TOKEN }}
 ```
@@ -61,7 +61,7 @@ Install NVIDIA CUDA Toolkit. Defaults to `true`. This flag can be set to `false`
 
 ```yml
 - name: Setup Cog
-  uses: replicate/setup-cog@v1
+  uses: replicate/setup-cog@v2
   with:
     install-cuda: true
 ```
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Cog
-        uses: replicate/setup-cog@v1
+        uses: replicate/setup-cog@v2
         with:
           token: ${{ secrets.REPLICATE_API_TOKEN }}
 
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Cog
-        uses: replicate/setup-cog@v1
+        uses: replicate/setup-cog@v2
         with:
           token: ${{ secrets.REPLICATE_API_TOKEN }}
 
@@ -149,5 +149,5 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Cog
-        uses: replicate/setup-cog@v1
+        uses: replicate/setup-cog@v2
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,10 @@ inputs:
   install-cuda:
     description: "Install NVIDIA CUDA Toolkit to build GPU-bound containers."
     required: false
-    default: 'true'
-
+    default: 'false'
+    options:
+      - true
+      - false
 
 runs:
   using: "composite"
@@ -27,7 +29,7 @@ runs:
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
   
       - name: Install NVIDIA CUDA Toolkit
-        if: ${{ inputs.install-cuda == 'true' }}
+        if: inputs.install-cuda == true || inputs.install-cuda == 'true'
         uses: Jimver/cuda-toolkit@dc0ca7bb29c5a92f7a963d3d5c93f8d59765136a # v0.2.14
 
       - name: Setup Cog

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   cog-version:
     description: "The version of Cog to install"
     required: false
-    default: "v0.8.6"
+    default: "v0.9.7"
   install-cuda:
     description: "Install NVIDIA CUDA Toolkit to build GPU-bound containers."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
 
       - name: Log in to Replicate
         shell: bash
-        if: ${{ inputs.token != '' }}
+        if: inputs.token != ''
         env:
           REPLICATE_API_TOKEN: ${{ inputs.token }}
         run: |


### PR DESCRIPTION
This PR includes two breaking changes which I want to roll out in a new major version v2:

1. Changes the `install_cuda` input to default to false. Most models don't need CUDA at build time. Workflows are much faster without it.
1. Changes the default version of Cog installed by the Action from 0.8.6 to 0.9.7

Resolves #31

cc @luismavs and @nateraw who originally had the bright idea to make CUDA optional: #13