### PR TITLE
configure buildx step to use docker driver

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,8 @@ runs:
   steps:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+        with:
+          driver: "docker"
   
       - name: Install NVIDIA CUDA Toolkit
         if: inputs.install-cuda == true || inputs.install-cuda == 'true'


### PR DESCRIPTION
This PR updates the docker buildx configuration to use the `docker` driver instead of the default `docker-container` driver.

@one1zero1one's thorough explanation of the issue:

> Okay so I figured out the issue, the reason why it goes out to pull the image from a registry - instead of using the locally build one - is the [buildx driver](https://docs.docker.com/reference/cli/docker/buildx/create/#driver), which is `docker-container` by default - when using [setup-cog](https://github.com/replicate/setup-cog).
> 
> I don't have enough context to understand if the `docker-container` driver is _required_ (i.e. multi-platform features), but [using `docker` driver ](https://github.com/docker/setup-buildx-action?tab=readme-ov-file#inputs) in the buildx setup got me over this error and being able to successfully build and push cogs.
> 
> I spent many frustrating hours to figure this out, so I'll mention _how_ I debugged - maybe it saves someone else time. I used `mxschmitt/action-tmate@v3` action to ssh into my runner, and then used `cog debug` and `cog build --debug` to see all the steps (thx to cog developers for exposing this). There I have seen that there are couple of steps, and the last one interprets `FROM r8.im/xxx/test`as to literally go and pull the image, instead of using the local image. Using the right buildx driver makes it do the right thing.

Resolves these issues:

- https://github.com/replicate/cog/issues/1723#issuecomment-2167882760
- https://github.com/replicate/cog/issues/1718#issuecomment-2168340396